### PR TITLE
A better bibtex.pegjs

### DIFF
--- a/src/bibtex/bibtex.pegjs
+++ b/src/bibtex/bibtex.pegjs
@@ -1,135 +1,276 @@
-Root
-  = __ content:(Entry)*
-  {
-      return { content };
-  }
+{
+    function simpleLatexConversions(text) {
+        return [
+            [/---/g, '\u2014'],
+            [/--/g, '\u2013'],
+            [/~/g, '\u00A0'],
+            [/</g, '\u00A1'],
+            [/>/g, '\u00BF'],
+        ].reduce((output, replacer) => {
+            output = output.replace(replacer[0], replacer[1]);
+            return output;
+        }, text);
+    }
 
+    function normalizeWhitespace(textArr) {
+        return textArr.reduce((prev, curr) => {
+            if (/\s/.test(curr)) {
+                if (/\s/.test(prev[prev.length - 1])) {
+                    return prev;
+                } else {
+                    return prev + ' ';
+                }
+            }
+            return prev + curr;
+        }, '');
+    }
+}
 
-Comment
-  = QuotedValue
-  / CurlyBracketValue
-  / '@comment'i __ '{' ( QuotedValue / CurlyBracketValue / [^}] )* '}'
-  / '@comment'i __ '(' ( QuotedValue / CurlyBracketValue / [^}] )* ')'
-  / [^@]
+File
+    = __ r:Node* __ {
+        return {
+            kind: 'File',
+            loc: location(),
+            children: r,
+        };
+    }
+
+Junk
+    = '@comment'i [^\n\r]* [\n\r]*
+    / [^@] [^\n\r]* [\n\r]*
+
+Node
+    = Junk* n:(PreambleExpression / StringExpression / Entry) Junk* { return n; }
+
+//-----------------  Top-level Nodes
 
 Entry
-  = x:Entry_p __
-  {
-      return x;
-  }
-  / Comment+ ( ' ' / '\r\n' / '\n' ) x:Entry_p __
-  {
-      return x;
-  }
+    = '@' type:$[A-Za-z]+ [({] __ id:EntryId? __ props:Property* __ [})] __ {
+        return {
+            kind: 'Entry',
+            id: id || '',
+            type: type.toLowerCase(),
+            loc: location(),
+            properties: props,
+        }
+    }
 
-Entry_p
-  = entryType:EntryType __ '{' __ internalKey:InternalKey? __
-      fields:FieldArray? __
-    '}'
-  {
-      return { entryType, content: fields || [], internalKey };
-  }
-  / entryType:EntryType __ '(' __ internalKey:InternalKey? __
-      fields:FieldArray? __
-    ')'
-  {
-      return { entryType, content: fields || [], internalKey };
-  }
+PreambleExpression
+    = '@preamble'i __ [({] __ v:RegularValue* __ [})] __ {
+        return {
+            kind: 'PreambleExpression',
+            loc: location(),
+            value: v.reduce((a, b) => a.concat(b), []),
+        }
+    }
 
-EntryType
-  = '@' type:$([a-zA-Z]+)
-  {
-      return type.toLowerCase();
-  }
+StringExpression
+    = '@string'i __ [({] __ k:VariableName PropertySeparator v:RegularValue+ __ [})] __ {
+        return {
+            kind: 'StringExpression',
+            loc: location(),
+            key: k,
+            value: v.reduce((a, b) => a.concat(b), []),
+        };
+    }
 
-StringEntry
-  = '@string'i __ '{' __ 
-       name:AbbreviationName __ '=' __ value:( CurlyBracketValue / QuotedValue / Number ) __
-    '}'
-  {
-      return { entryType: 'string', abbreviation: name, value };
-  }
-  /  '@string'i __ '(' __ 
-       name:AbbreviationName __ '=' __ value:( CurlyBracketValue / QuotedValue / Number ) __
-    ')'
-  {
-      return { entryType: 'string', abbreviation: name, value };
-  }
+//------------------ Entry Child Nodes
 
-PreambleEntry
-  = '@preamble'i __ '{' __
-       content:( CurlyBracketValue / QuotedValue / Concat ) __
-    '}'
-  {
-      return { entryType: 'preamble', content };
-  }
-  / '@preamble'i __ '(' __
-       value:( CurlyBracketValue / QuotedValue / Concat ) __
-    ')'
-  {
-      return { entryType: 'preamble', content };
-  }
+EntryId
+    = __ id:$[^ \t\r\n,]* __ ',' { return id; }
 
-InternalKey
-  = name:Name __ ','
-  {
-      return name;
-  }
+Property
+    = k:PropertyKey PropertySeparator v:PropertyValue PropertyTerminator {
+        return {
+            kind: 'Property',
+            loc: location(),
+            key: k.toLowerCase(),
+            value: v,
+        }
+    }
 
-FieldArray
-  = fields:(x:Field __ ',' __ { return x; } )* last:Field __ ','?
-  {
-      return fields.concat([last]);
-  }
+PropertyKey
+    = __ k:$[a-zA-Z0-9-_]+ { return k; }
 
-Field
-  = name:FieldName __ '=' __ value:( CurlyBracketValue / QuotedValue / Number / Abbreviation / Concat )
-  {
-      return { name, value };
-  }
+//----------------------- Value Descriptors
 
-FieldName = NameToLowerCase
+PropertyValue
+    = Number
+    / v:(RegularValue / StringValue)* {
+        return v.reduce((a, b) => a.concat(b), []);
+    }
 
-Concat
-  = x:(ConcatElement __ '#' __ { return x; })+ last:ConcatElement
-  {
-      return { kind: 'concat', content: x.concat([last]) };
-  }
+RegularValue
+    = '"' v:(NestedLiteral / Command / TextNoQuotes)* '"' Concat? { return v; }
+    / '{' v:(NestedLiteral / Command / Text)* '}' Concat? { return v; }
 
-ConcatElement = CurlyBracketValue / QuotedValue / Number / Abbreviation
+StringValue
+    = v:String Concat? { return v; }
 
-CurlyBracketValue
-  = '{' content:$(( '\\{' / '\\}' / CurlyBracketValue / [^}] )*) '}'
-  {
-      return { kind: 'value', content };
-  }
+//---------------------- Value Kinds
 
-QuotedValue
-  = '"' content:$(( CurlyBracketValue / [^"] )*) '"'
-  {
-      return { kind: 'value', content };
-  }
+Text
+    = v:[^{}\\]+ {
+        return {
+            kind: 'Text',
+            loc: location(),
+            value: simpleLatexConversions(normalizeWhitespace(v)),
+        };
+    }
 
-Abbreviation
-  = content:AbbreviationName
-  {
-      return { kind: 'abbreviation', content };
-  }
+TextNoQuotes
+    = v:[^{}"\\]+ {
+        return {
+            kind: 'Text',
+            loc: location(),
+            value: simpleLatexConversions(normalizeWhitespace(v)),
+        };
+    }
 
 Number
-  = content:$([0-9]+)
-  {
-      return { kind: 'number', content };
-  }
+    = v:$[0-9]+ {
+        return {
+            kind: 'Number',
+            loc: location(),
+            value: parseInt(v, 10),
+        };
+    }
 
-AbbreviationName = $([a-zA-Z]+)
+String
+    = v:VariableName {
+        return {
+            kind: 'String',
+            loc: location(),
+            value: v,
+        };
+    }
 
-NameToLowerCase
-  = n:Name
-  {
-      return n.toLowerCase();
-  }
+NestedLiteral
+    = '{' v:(Text / Command / NestedLiteral)* '}' {
+        return {
+            kind: 'NestedLiteral',
+            loc: location(),
+            value: v,
+        };
+    }
 
-Name = $([^@={}", \t\r\n]+)
 
-__ = ('\r\n' / [ \t\n])*
+//---------------- Comments
+
+LineComment
+    = '%' __h v:$[^\r\n]+ EOL+ {
+        return {
+            kind: 'LineComment',
+            loc: location(),
+            value: v,
+        };
+    }
+
+
+//---------------------- LaTeX Commands
+
+Command
+    = DicraticalCommand
+    / RegularCommand
+    / SymbolCommand
+
+DicraticalCommand
+    = '\\' mark:SimpleDicratical char:[a-zA-Z0-9] {
+        return {
+            kind: 'DicraticalCommand',
+            loc: location(),
+            mark: mark,
+            character: char,
+        };
+    }
+    / '\\' mark:ExtendedDicratical '{' char:[a-zA-Z0-9] '}' {
+        return {
+            kind: 'DicraticalCommand',
+            loc: location(),
+            mark: mark,
+            character: char,
+        }
+    }
+
+
+SymbolCommand
+    = '\\' v:$[^A-Za-z0-9\t\r\n] {
+        return {
+            kind: 'SymbolCommand',
+            loc: location(),
+            value: v,
+        };
+    }
+
+RegularCommand
+    = '\\' v:$[A-Za-z]+ args:Argument* {
+        return {
+            kind: 'RegularCommand',
+            loc: location(),
+            value: v,
+            arguments: args,
+        };
+    }
+
+Argument
+    = RequiredArgument
+    / OptionalArgument
+
+OptionalArgument
+    = '[' __h v:$[^\]]+ __h ']' {
+        return {
+            kind: 'OptionalArgument',
+            loc: location(),
+            value: v,
+        }
+    }
+
+RequiredArgument
+    = '{' __h v:(Command / Text)* __h '}' {
+        return {
+            kind: 'RequiredArgument',
+            loc: location(),
+            value: v,
+        }
+    }
+
+//-------------- Helpers
+
+VariableName
+    = $([a-zA-Z-_][a-zA-Z0-9-_:]+)
+
+SimpleDicratical
+    = ['`=~^.]
+
+ExtendedDicratical
+    = ['`"c=buv~^.drHk]
+
+PropertySeparator
+    = __h '=' __h
+
+PropertyTerminator
+    = __ ','? __h (LineComment / EOL)*
+
+Concat
+    = __ '#' __
+
+EOL
+    = [\r\n]
+
+_h "Mandatory Horizontal Whitespace"
+    = [ \t]+
+
+__h "Optional Horizontal Whitespace"
+    = [ \t]*
+
+_v "Mandatory Vertical Whitespace"
+    = [\r\n]+
+
+__v "Optional Vertical Whitespace"
+    = [\r\n]*
+
+_ "Mandatory Whitespace"
+    = [ \t\n\r]+
+
+__ "Optional Whitespace"
+    = [ \t\n\r]*


### PR DESCRIPTION
This seems to be a better peg definition for bibtex. I've tested it with several pieces of bib files on my hand, and the original one cannot parse a few of them. This one resolves the problem.

For instance, the following parts throw different errors with the original one:
```
% Encoding: UTF-8

@Article{Lee_Robustvehiclerouting_2012,
  author    = {Lee, Chungmok and Lee, Kyungsik and Park, Sungsoo},
  title     = {Robust vehicle routing problem with deadlines and travel time/demand uncertainty},
  journal   = {Journal of the Operational Research Society},
  year      = {2012},
  volume    = {63},
  number    = {9},
  pages     = {1294--1306},
  doi       = {10.1057/jors.2011.136},
  file      = {:Lee_Robustvehiclerouting_2012 - Robust vehicle routing problem with deadlines and travel time_demand uncertainty.pdf:PDF},
  publisher = {Springer},
}
```

```
@Article{Lee_Robustvehiclerouting_2012,
  author    = {Lee, Chungmok and Lee, Kyungsik and Park, Sungsoo},
  title     = {Robust vehicle routing problem with deadlines and travel time/demand uncertainty},
  journal   = {Journal of the Operational Research Society},
  year      = {2012},
  volume    = {63},
  number    = {9},
  pages     = {1294--1306},
  doi       = {10.1057/jors.2011.136},
  file      = {:Lee_Robustvehiclerouting_2012 - Robust vehicle routing problem with deadlines and travel time_demand uncertainty.pdf:PDF},
  publisher = {Springer},
}
```