### PR TITLE
Incompatible superscript and subscript between math mode and text mode

### DIFF
--- a/src/latex/latex.pegjs
+++ b/src/latex/latex.pegjs
@@ -91,8 +91,8 @@ MathElement_p
   / MathGroup
   / AlignmentTab
   / CommandParameterWithNumber
-  / Superscript skip_space x:MathElement { return { kind: "superscript", content: x, location: location() }; }
-  / Subscript skip_space x:MathElement { return { kind: "subscript", content: x, location: location() }; }
+  / Superscript skip_space x:MathElement { return { kind: "superscript", content: [x], location: location() }; }
+  / Subscript skip_space x:MathElement { return { kind: "subscript", content: [x], location: location() }; }
   / ActiveCharacter
   / ignore
   / c:$(!nonMathcharToken .) { return { kind: "math.character", content: c }; }

--- a/test/test_latex_parser.ts
+++ b/test/test_latex_parser.ts
@@ -382,7 +382,7 @@ Some sentences.
                         { kind: 'math.character', content: 'a'},
                         {
                             kind: 'superscript',
-                            content: { kind: 'math.character', content: 'b' }
+                            content: [{ kind: 'math.character', content: 'b' }]
                         }
                     ]
                 } ]


### PR DESCRIPTION
As the superscript and subscript in math mode are incompatible with them in text mode,
I updated the parser and test case.

According to the type definitions, the `content` of `{ kind: 'superscript', ... }` should have an array of Node but it was not. Thus, I make them compatible with  them in text mode.