### PR TITLE
Make `\label` accept an optional argument

### DIFF
--- a/src/latex/latex.pegjs
+++ b/src/latex/latex.pegjs
@@ -150,7 +150,11 @@ SpecialCommand "special command"
 
 // \label{...} \ref{...}
 LabelCommand
-  = escape name:("label" / "ref" / "eqref" / "autoref") skip_space beginGroup label:labelString endGroup
+  = escape name:("ref" / "eqref" / "autoref") skip_space beginGroup label:labelString endGroup
+  {
+    return { kind: "command.label", name, label: label.join(''), location: location() };
+  }
+  / escape name:("label") skip_space ArgumentList? beginGroup label:labelString endGroup
   {
     return { kind: "command.label", name, label: label.join(''), location: location() };
   }


### PR DESCRIPTION
The widely used `cleveref` package redefines the `\label` command to accept an optional argument (See http://tug.ctan.org/tex-archive/macros/latex/contrib/cleveref/cleveref.pdf Section 6).

Currently, a node containing `\label[optarg]{some_label}` is not considered as a `LabelCommand` but as a standard one, which makes its parsing a pain. What do you think of allowing a `LabelCommand` to have an optional argument?

My PR is currently not good as I drop the optional argument. If you think this is worth accepting an optional arg for labels, I will do things right and add a field `arg: OptionalArg | undefined;` to `LabelCommand` type.